### PR TITLE
Implement basic respondTo and deliverWithResponse

### DIFF
--- a/examples/echo_client.hs
+++ b/examples/echo_client.hs
@@ -1,4 +1,4 @@
-{-# OPTIONS -XOverloadedStrings #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE DeriveGeneric #-}
 
 import qualified Network.Freddy as Freddy

--- a/examples/echo_client.hs
+++ b/examples/echo_client.hs
@@ -1,0 +1,24 @@
+{-# OPTIONS -XOverloadedStrings #-}
+{-# LANGUAGE DeriveGeneric #-}
+
+import qualified Network.Freddy as Freddy
+import GHC.Generics (Generic)
+import Data.Aeson (ToJSON, encode)
+
+data EchoRequest = EchoRequest {
+  message :: String
+} deriving (Generic, Show)
+
+instance ToJSON EchoRequest
+
+echo body = do
+  let request = EchoRequest { message = body }
+  (_, deliverWithResponse) <- Freddy.connect "127.0.0.1" "/" "guest" "guest"
+
+  responseBody <- deliverWithResponse "EchoServer" (encode request)
+  putStrLn $ "Got response: " ++ show responseBody
+
+main = do
+  putStrLn "Start echo_server.hs and execute:"
+  putStrLn "  echo \"cookie monster\""
+  putStrLn ""

--- a/examples/echo_server.hs
+++ b/examples/echo_server.hs
@@ -3,8 +3,8 @@
 import qualified Network.Freddy as Freddy
 import Data.ByteString.Lazy.Char8 (ByteString)
 
-processMessage :: ByteString -> Either ByteString ByteString
-processMessage rawRequest = Right rawRequest
+processMessage :: Freddy.Request -> IO ()
+processMessage (Freddy.Request body replyWith failWith) = replyWith body
 
 main = do
   fConnection <- Freddy.connect "127.0.0.1" "/" "guest" "guest"

--- a/examples/echo_server.hs
+++ b/examples/echo_server.hs
@@ -7,9 +7,9 @@ processMessage :: Freddy.Request -> IO ()
 processMessage (Freddy.Request body replyWith failWith) = replyWith body
 
 main = do
-  fConnection <- Freddy.connect "127.0.0.1" "/" "guest" "guest"
+  (respondTo, _) <- Freddy.connect "127.0.0.1" "/" "guest" "guest"
 
-  Freddy.respondTo fConnection "EchoServer" processMessage
+  respondTo "EchoServer" processMessage
 
   putStrLn "Service started!"
   putStrLn ""

--- a/examples/echo_server.hs
+++ b/examples/echo_server.hs
@@ -1,4 +1,4 @@
-{-# OPTIONS -XOverloadedStrings #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 import qualified Network.Freddy as Freddy
 import Data.ByteString.Lazy.Char8 (ByteString)

--- a/examples/echo_server.hs
+++ b/examples/echo_server.hs
@@ -1,0 +1,18 @@
+{-# OPTIONS -XOverloadedStrings #-}
+
+import qualified Network.Freddy as Freddy
+import Data.ByteString.Lazy.Char8 (ByteString)
+
+processMessage :: ByteString -> Either ByteString ByteString
+processMessage rawRequest = Right rawRequest
+
+main = do
+  fConnection <- Freddy.connect "127.0.0.1" "/" "guest" "guest"
+
+  Freddy.respondTo fConnection "EchoServer" processMessage
+
+  putStrLn "Service started!"
+  putStrLn ""
+  putStrLn "Sample usage using ruby:"
+  putStrLn "  freddy.deliver_with_response 'EchoServer', message: 'hello there'"
+  putStrLn ""

--- a/freddy.cabal
+++ b/freddy.cabal
@@ -12,13 +12,31 @@ cabal-version:       >=1.10
 library
   exposed-modules:   Network.Freddy
   build-depends:
-    base        >= 4.8 && < 5,
-    bytestring  >= 0.9,
-    text        >= 0.11.2,
-    amqp        >= 0.13.1
+    base           >= 4.8 && < 5,
+    bytestring     >= 0.9,
+    text           >= 0.11.2,
+    amqp           >= 0.13.1,
+    broadcast-chan >= 0.1.0,
+    uuid           >= 1.3.11,
+    random         >= 1.1
   hs-source-dirs:    src
   default-language:  Haskell2010
 
 source-repository head
   type:     git
   location: https://github.com/salemove/freddy-hs
+
+test-suite spec
+  type: exitcode-stdio-1.0
+  hs-source-dirs: src, test
+  main-is: Spec.hs
+  build-depends:
+    hspec          >= 1.3,
+    base           >= 4.8 && < 5,
+    bytestring     >= 0.9,
+    text           >= 0.11.2,
+    amqp           >= 0.13.1,
+    broadcast-chan >= 0.1.0,
+    uuid           >= 1.3.11,
+    random         >= 1.1
+  default-language: Haskell2010

--- a/src/Network/Freddy.hs
+++ b/src/Network/Freddy.hs
@@ -1,0 +1,48 @@
+{-# OPTIONS -XOverloadedStrings #-}
+module Network.Freddy (connect, respondTo) where
+
+import Network.AMQP
+import Data.Text (Text, pack)
+import Data.ByteString.Lazy.Char8 (ByteString)
+import Network.Freddy.Result
+
+connect :: String -> Text -> Text -> Text -> IO Connection
+connect host vhost user password =
+  openConnection host vhost user password
+
+respondTo :: Connection -> String -> (ByteString -> Either ByteString ByteString) -> IO ConsumerTag
+respondTo conn queueName callback = do
+  chan <- openChannel conn
+
+  declareQueue chan newQueue {queueName = pack queueName}
+
+  consumeMsgs chan (pack queueName) NoAck (replyCallback callback chan)
+
+replyCallback :: (ByteString -> Either ByteString ByteString) -> Channel -> (Message, Envelope) -> IO ()
+replyCallback userCallback channel (msg, env) = do
+  let (resType, body) = processRequest userCallback msg
+
+  case buildReply msg resType body of
+    Just (queueName, reply) -> (publishMsg channel "" queueName reply)
+    Nothing -> putStrLn $ "Could not reply"
+
+buildReply :: Message -> Result -> ByteString -> Maybe (Text, Message)
+buildReply originalMsg resType body = do
+  queueName <- msgReplyTo originalMsg
+
+  let reply = newMsg {
+    msgBody          = body,
+    msgCorrelationID = msgCorrelationID originalMsg,
+    msgDeliveryMode  = Just NonPersistent,
+    msgType          = Just $ pack $ show resType
+  }
+
+  Just $ (queueName, reply)
+
+processRequest :: (ByteString -> Either ByteString ByteString) -> Message -> (Result, ByteString)
+processRequest userCallback msg = do
+  let requestBody = msgBody msg
+
+  case userCallback requestBody of
+    Right r -> (Success, r)
+    Left r -> (Error, r)

--- a/src/Network/Freddy.hs
+++ b/src/Network/Freddy.hs
@@ -1,4 +1,4 @@
-{-# OPTIONS -XOverloadedStrings #-}
+{-# LANGUAGE OverloadedStrings #-}
 module Network.Freddy (connect, Request (..), Error (..)) where
 
 import qualified Network.AMQP as AMQP
@@ -82,7 +82,7 @@ sendReply :: AMQP.Message -> AMQP.Channel -> ResultType -> ReplyBody -> IO ()
 sendReply originalMsg channel resType body =
   case buildReply originalMsg resType body of
     Just (Reply queueName message) -> AMQP.publishMsg channel "" queueName message
-    Nothing -> putStrLn $ "Could not reply"
+    Nothing -> putStrLn "Could not reply"
 
 buildReply :: AMQP.Message -> ResultType -> ReplyBody -> Maybe Reply
 buildReply originalMsg resType body = do
@@ -103,10 +103,10 @@ deliverWithResponse channel responseQueueName responseChannelListener queueName 
 
   let msg = AMQP.newMsg {
     AMQP.msgBody          = body,
-    AMQP.msgCorrelationID = Just $ correlationId,
+    AMQP.msgCorrelationID = Just correlationId,
     AMQP.msgDeliveryMode  = Just AMQP.NonPersistent,
-    AMQP.msgType          = Just $ "request",
-    AMQP.msgReplyTo       = Just $ responseQueueName
+    AMQP.msgType          = Just "request",
+    AMQP.msgReplyTo       = Just responseQueueName
   }
 
   AMQP.publishMsg' channel "" queueName True msg

--- a/src/Network/Freddy.hs
+++ b/src/Network/Freddy.hs
@@ -12,8 +12,7 @@ type FailWith    = ByteString -> IO ()
 data Request     = Request RequestBody ReplyWith FailWith
 
 connect :: String -> Text -> Text -> Text -> IO Connection
-connect host vhost user password =
-  openConnection host vhost user password
+connect = openConnection
 
 respondTo :: Connection -> String -> (Request -> IO ()) -> IO ()
 respondTo conn queueName callback = do

--- a/src/Network/Freddy/Result.hs
+++ b/src/Network/Freddy/Result.hs
@@ -1,8 +1,0 @@
-module Network.Freddy.Result (Result (..)) where
-
-data Result = Success | Error
-
-instance Show Result where
-  show res = case res of
-    Success -> "success"
-    Error -> "error"

--- a/src/Network/Freddy/Result.hs
+++ b/src/Network/Freddy/Result.hs
@@ -1,0 +1,8 @@
+module Network.Freddy.Result (Result (..)) where
+
+data Result = Success | Error
+
+instance Show Result where
+  show res = case res of
+    Success -> "success"
+    Error -> "error"

--- a/src/Network/Freddy/ResultType.hs
+++ b/src/Network/Freddy/ResultType.hs
@@ -1,0 +1,7 @@
+module Network.Freddy.ResultType (ResultType (..), serializeResultType) where
+
+data ResultType = Success | Error
+
+serializeResultType resType = case resType of
+  Success -> "success"
+  Error -> "error"

--- a/src/Network/Freddy/ResultType.hs
+++ b/src/Network/Freddy/ResultType.hs
@@ -1,7 +1,10 @@
 module Network.Freddy.ResultType (ResultType (..), serializeResultType) where
 
+import Data.Text (Text, pack)
+
 data ResultType = Success | Error
 
+serializeResultType :: ResultType -> Text
 serializeResultType resType = case resType of
-  Success -> "success"
-  Error -> "error"
+  Success -> pack "success"
+  Error -> pack "error"

--- a/test/Network/FreddySpec.hs
+++ b/test/Network/FreddySpec.hs
@@ -47,3 +47,12 @@ spec = do
       let response = deliverWithResponse queueName requestBody
 
       response `shouldReturn` Left Freddy.TimeoutError
+
+    it "returns a invalid request error when queue does not exist" $ do
+      (respondTo, deliverWithResponse) <- Freddy.connect "127.0.0.1" "/" "guest" "guest"
+      queueName <- randomQueueName
+
+      let requestBody = "msg body"
+      let response = deliverWithResponse queueName requestBody
+
+      response `shouldReturn` Left Freddy.InvalidRequest

--- a/test/Network/FreddySpec.hs
+++ b/test/Network/FreddySpec.hs
@@ -7,52 +7,42 @@ import Data.UUID (UUID, toText)
 import Data.Text (Text)
 import Control.Concurrent (threadDelay)
 import qualified Network.Freddy as Freddy
-
-newUUID :: IO UUID
-newUUID = randomIO
-
-randomQueueName :: IO Text
-randomQueueName = do
-  uuid <- newUUID
-  return $ toText uuid
-
-echoResponder (Freddy.Request body replyWith failWith) = do
-  replyWith body
-
-delayedResponder (Freddy.Request body replyWith failWith) = do
-  threadDelay $ 4 * 1000 * 1000 -- 4 seconds
-  replyWith body
+import SpecHelper (
+  newUUID,
+  randomQueueName,
+  echoResponder,
+  delayedResponder,
+  connect,
+  requestBody
+  )
 
 spec :: Spec
 spec = do
   describe "Freddy" $ do
     it "can respond to messages" $ do
-      (respondTo, deliverWithResponse) <- Freddy.connect "127.0.0.1" "/" "guest" "guest"
+      (respondTo, deliverWithResponse) <- connect
       queueName <- randomQueueName
 
       respondTo queueName echoResponder
 
-      let requestBody = "msg body"
       let response = deliverWithResponse queueName requestBody
 
       response `shouldReturn` Right requestBody
 
     it "handles timeouts" $ do
-      (respondTo, deliverWithResponse) <- Freddy.connect "127.0.0.1" "/" "guest" "guest"
+      (respondTo, deliverWithResponse) <- connect
       queueName <- randomQueueName
 
       respondTo queueName delayedResponder
 
-      let requestBody = "msg body"
       let response = deliverWithResponse queueName requestBody
 
       response `shouldReturn` Left Freddy.TimeoutError
 
     it "returns a invalid request error when queue does not exist" $ do
-      (respondTo, deliverWithResponse) <- Freddy.connect "127.0.0.1" "/" "guest" "guest"
+      (_, deliverWithResponse) <- connect
       queueName <- randomQueueName
 
-      let requestBody = "msg body"
       let response = deliverWithResponse queueName requestBody
 
       response `shouldReturn` Left Freddy.InvalidRequest

--- a/test/Network/FreddySpec.hs
+++ b/test/Network/FreddySpec.hs
@@ -1,0 +1,33 @@
+{-# OPTIONS -XOverloadedStrings #-}
+module Network.FreddySpec where
+
+import Test.Hspec
+import System.Random (randomIO)
+import Data.UUID (UUID, toText)
+import Data.Text (Text)
+import qualified Network.Freddy as Freddy
+
+newUUID :: IO UUID
+newUUID = randomIO
+
+randomQueueName :: IO Text
+randomQueueName = do
+  uuid <- newUUID
+  return $ toText uuid
+
+echoResponder (Freddy.Request body replyWith failWith) = do
+  replyWith body
+
+spec :: Spec
+spec = do
+  describe "Freddy" $ do
+    it "can respond to messages" $ do
+      (respondTo, deliverWithResponse) <- Freddy.connect "127.0.0.1" "/" "guest" "guest"
+      queueName <- randomQueueName
+
+      respondTo queueName echoResponder
+
+      let requestBody = "msg body"
+      responseBody <- deliverWithResponse queueName requestBody
+
+      responseBody `shouldBe` requestBody

--- a/test/Network/FreddySpec.hs
+++ b/test/Network/FreddySpec.hs
@@ -1,4 +1,4 @@
-{-# OPTIONS -XOverloadedStrings #-}
+{-# LANGUAGE OverloadedStrings #-}
 module Network.FreddySpec where
 
 import Test.Hspec
@@ -17,7 +17,7 @@ import SpecHelper (
   )
 
 spec :: Spec
-spec = do
+spec =
   describe "Freddy" $ do
     it "can respond to messages" $ do
       (respondTo, deliverWithResponse) <- connect

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,0 +1,1 @@
+{-# OPTIONS_GHC -F -pgmF hspec-discover #-}

--- a/test/SpecHelper.hs
+++ b/test/SpecHelper.hs
@@ -1,4 +1,4 @@
-{-# OPTIONS -XOverloadedStrings #-}
+{-# LANGUAGE OverloadedStrings #-}
 module SpecHelper where
   import System.Random (randomIO)
   import Data.UUID (UUID, toText)
@@ -15,7 +15,7 @@ module SpecHelper where
     uuid <- newUUID
     return $ toText uuid
 
-  echoResponder (Freddy.Request body replyWith failWith) = do
+  echoResponder (Freddy.Request body replyWith failWith) =
     replyWith body
 
   delayedResponder (Freddy.Request body replyWith failWith) = do

--- a/test/SpecHelper.hs
+++ b/test/SpecHelper.hs
@@ -1,0 +1,28 @@
+{-# OPTIONS -XOverloadedStrings #-}
+module SpecHelper where
+  import System.Random (randomIO)
+  import Data.UUID (UUID, toText)
+  import Data.Text (Text)
+  import Control.Concurrent (threadDelay)
+  import qualified Network.Freddy as Freddy
+  import Data.ByteString.Lazy.Char8 (ByteString)
+
+  newUUID :: IO UUID
+  newUUID = randomIO
+
+  randomQueueName :: IO Text
+  randomQueueName = do
+    uuid <- newUUID
+    return $ toText uuid
+
+  echoResponder (Freddy.Request body replyWith failWith) = do
+    replyWith body
+
+  delayedResponder (Freddy.Request body replyWith failWith) = do
+    threadDelay $ 4 * 1000 * 1000 -- 4 seconds
+    replyWith body
+
+  connect = Freddy.connect "127.0.0.1" "/" "guest" "guest"
+
+  requestBody :: ByteString
+  requestBody = "request body"


### PR DESCRIPTION
Adds `respondTo` and `deliverWithResponse` support.

There's one major difference between this and ruby/node freddy. This one does not parse json itself. It gives bytestring to the client and the client must return a bytestring as a response.

This could be improved a lot. I appreciate all feedback.

/cc @urmastalimaa 
